### PR TITLE
Fix URL's in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in gitomator/classroom.gemspec
 gemspec
 
-gem 'gitomator-github', :git => 'git@github.com:Gitomator/gitomator-github.git'
-gem 'gitomator-travis', :git => 'git@github.com:Gitomator/gitomator-travis.git'
+gem 'gitomator-github', :git => 'https://github.com/gitomator/gitomator-github.git'
+gem 'gitomator-travis', :git => 'https://github.com/gitomator/gitomator-travis.git'


### PR DESCRIPTION
The URL's in the Gemfile were using the `ssh` (i.e. `git`), instead of `https`.
That means that tools like Travis CI could not build the project and run the tests.